### PR TITLE
Add initiate login endpoint to /login

### DIFF
--- a/src/app/actions/getSignInUrl.ts
+++ b/src/app/actions/getSignInUrl.ts
@@ -1,7 +1,0 @@
-"use server";
-
-import { getSignInUrl } from "@workos-inc/authkit-nextjs";
-
-export const getSignInUrlAction = async () => {
-  return await getSignInUrl();
-};

--- a/src/app/components/sign-in-button.tsx
+++ b/src/app/components/sign-in-button.tsx
@@ -6,17 +6,10 @@
 
 import { Button, Flex } from "@radix-ui/themes";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
-import { useEffect, useState } from "react";
-import { getSignInUrlAction } from "../actions/getSignInUrl";
 import { handleSignOutAction } from "../actions/signOut";
 
 export function SignInButton({ large }: { large?: boolean }) {
   const { user, loading } = useAuth();
-  const [signInUrl, setSignInUrl] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    getSignInUrlAction().then(setSignInUrl);
-  }, []);
 
   if (loading) {
     return <div>Loading...</div>;
@@ -36,7 +29,7 @@ export function SignInButton({ large }: { large?: boolean }) {
 
   return (
     <Button asChild size={large ? "3" : "2"}>
-      <a href={signInUrl}>Sign In {large && "with AuthKit"}</a>
+      <a href="/login">Sign In {large && "with AuthKit"}</a>
     </Button>
   );
 }

--- a/src/app/login/route.ts
+++ b/src/app/login/route.ts
@@ -1,0 +1,8 @@
+import { getSignInUrl } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+
+export const GET = async () => {
+  const signInUrl = await getSignInUrl();
+
+  return redirect(signInUrl);
+};


### PR DESCRIPTION
We encourage customers to set [an initiate login URL](https://workos.com/docs/user-management/client-only/1-configure-your-project/configure-initiate-login-url). The Next.js AuthKit example doesn't currently have an endpoint we can use to configure that.

This PR introduces a new `/login` endpoint that redirects to the AuthKit login page that we can set as the initiate login URL in the WorkOS Dashboard. It uses that endpoint in the `<SignInButton>` component to avoid some `useEffect`/`useState` funny business.